### PR TITLE
fix(ci): resolve Cloud Run org policy restriction for invoker IAM

### DIFF
--- a/.github/gcp/kai-ba-cloudrun.yml
+++ b/.github/gcp/kai-ba-cloudrun.yml
@@ -11,6 +11,8 @@ metadata:
     run.googleapis.com/ingress-status: all
     run.googleapis.com/minScale: '0'
     run.googleapis.com/urls: '["https://kai-ba-415813429517.asia-northeast1.run.app"]'
+    # 明確設定允許未經身份驗證的訪問
+    run.googleapis.com/invoker-iam-disabled: 'false'
 spec:
   template:
     metadata:


### PR DESCRIPTION
- Add run.googleapis.com/invoker-iam-disabled: 'false' annotation to Cloud Run YAML
- Keep Python-based YAML processing for safe deployment configuration updates
- Maintain YAML-based deployment approach with proper IAM settings
- Fix org policy compliance issue that was blocking Cloud Run deployments

This resolves the 'Changes to invoker_iam_disabled are disallowed by org policy' error by explicitly setting the invoker IAM policy in the service configuration.